### PR TITLE
Исправление отправки тела в GET-запросе

### DIFF
--- a/src/TochkaApi/Api.php
+++ b/src/TochkaApi/Api.php
@@ -157,7 +157,7 @@ class Api
         $response = $this->getAdapter()->request(
             $method,
             $url,
-            json_encode($data),
+            $data ? json_encode($data) : $data,
             $this->getHeaders()
         );
 

--- a/src/TochkaApi/Client.php
+++ b/src/TochkaApi/Client.php
@@ -81,6 +81,11 @@ final class Client
         "ReadCustomerData",
         "ReadSBPData",
         "EditSBPData",
+        "ReadCardData",
+        "EditCardData",
+        "EditCardState",
+        "ReadCardLimits",
+        "EditCardLimits",
         "CreatePaymentForSign",
         "CreatePaymentOrder"
     ];

--- a/src/TochkaApi/Client.php
+++ b/src/TochkaApi/Client.php
@@ -81,11 +81,6 @@ final class Client
         "ReadCustomerData",
         "ReadSBPData",
         "EditSBPData",
-        "ReadCardData",
-        "EditCardData",
-        "EditCardState",
-        "ReadCardLimits",
-        "EditCardLimits",
         "CreatePaymentForSign",
         "CreatePaymentOrder"
     ];


### PR DESCRIPTION
Присутствовала проблема отправки тела вида "{[]}" в GET-запросе, до 18 ноября со стороны банка не было проверки на соблюдение json(со слов поддержки).
Проверка на добавление тела в запрос была, но она всегда отрабатывала из-за того, что в метод, составляющий объект CURL, прокидывалась json-строка и при конвертации пустого массива мы получаем не пустую строку, а строку вида "{[]}"

Для исправления бага ввел проверку на моменте конвертации